### PR TITLE
Parametrize button toolbars

### DIFF
--- a/Example.ipynb
+++ b/Example.ipynb
@@ -17,24 +17,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hello"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "a"
    ]
@@ -42,7 +31,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "This is a markdown cell."
+   ]
   },
   {
    "cell_type": "code",
@@ -54,7 +45,9 @@
   {
    "cell_type": "raw",
    "metadata": {},
-   "source": []
+   "source": [
+    "This is a raw cell"
+   ]
   },
   {
    "cell_type": "code",
@@ -66,9 +59,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3 (jlab3) *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-jlab3-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -80,7 +73,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -6,7 +6,9 @@
     "defaultTags": {
       "title": "List of Default Tags",
       "description": "List of tags to always display for quick selection.",
-      "default": ["parameters"],
+      "default": [
+        "parameters"
+      ],
       "type": "array",
       "items": {
         "type": "string",
@@ -15,12 +17,16 @@
     },
     "leftMenu": {
       "title": "List of left menu items",
-      "description": "",
+      "description": "An item is defined by a 'command' name and an 'icon' name + optionally a 'tooltip' and the 'cellType' on which it applies",
       "oneOf": [
-        { "type": "null" },
+        {
+          "type": "null"
+        },
         {
           "type": "array",
-          "items": { "$ref": "#/definitions/menuItem" }
+          "items": {
+            "$ref": "#/definitions/menuItem"
+          }
         }
       ],
       "default": [
@@ -51,14 +57,19 @@
     },
     "rightMenu": {
       "title": "List of left menu items",
-      "description": "",
+      "description": "An item is defined by a 'command' name and an 'icon' name + optionally a 'tooltip' and the 'cellType' on which it applies",
       "oneOf": [
-        { "type": "null" },
+        {
+          "type": "null"
+        },
         {
           "type": "array",
-          "items": { "$ref": "#/definitions/menuItem" }
+          "items": {
+            "$ref": "#/definitions/menuItem"
+          }
         }
-      ]
+      ],
+      "default": null
     }
   },
   "additionalProperties": false,
@@ -67,13 +78,29 @@
     "menuItem": {
       "type": "object",
       "properties": {
-        "command": { "type": "string" },
-        "icon": { "type": "string" },
-        "tooltip": { "type": "string" },
-        "cellType": { "type": "string" }
+        "command": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "tooltip": {
+          "type": "string"
+        },
+        "cellType": {
+          "type": "string",
+          "enum": [
+            "code",
+            "markdown",
+            "raw"
+          ]
+        }
       },
       "additionalProperties": false,
-      "required": ["command", "icon"]
+      "required": [
+        "command",
+        "icon"
+      ]
     }
   }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Cell Toolbar",
   "description": "Cell Toolbar Settings.",
   "properties": {
@@ -11,8 +12,68 @@
         "type": "string",
         "pattern": "^[\\w-]+$"
       }
+    },
+    "leftMenu": {
+      "title": "List of left menu items",
+      "description": "",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/menuItem" }
+        }
+      ],
+      "default": [
+        {
+          "className": "jp-enh-cell-to-code",
+          "command": "notebook:change-cell-to-code",
+          "icon": "@jlab-enhanced/cell-toolbar:code",
+          "tooltip": "Convert to Code Cell"
+        },
+        {
+          "className": "jp-enh-cell-to-md",
+          "command": "notebook:change-cell-to-markdown",
+          "icon": "ui-components:markdown",
+          "tooltip": "Convert to Markdown Cell"
+        },
+        {
+          "className": "jp-enh-cell-format",
+          "command": "jupyterlab_code_formatter:format",
+          "icon": "@jlab-enhanced/cell-toolbar:format",
+          "tooltip": "Format Cell"
+        },
+        {
+          "command": "notebook:delete-cell",
+          "icon": "@jlab-enhanced/cell-toolbar:delete",
+          "tooltip": "Delete Selected Cells"
+        }
+      ]
+    },
+    "rightMenu": {
+      "title": "List of left menu items",
+      "description": "",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/menuItem" }
+        }
+      ],
     }
   },
   "additionalProperties": false,
-  "type": "object"
+  "type": "object",
+  "definitions": {
+    "menuItem": {
+      "type": "object",
+      "properties": {
+        "command": { "type": "string" },
+        "icon": { "type": "string" },
+        "tooltip": { "type": "string" },
+        "className": { "type": "string" }
+      },
+      "additionalProperties": false,
+      "required": ["command", "icon"]
+    }
+  }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -25,19 +25,19 @@
       ],
       "default": [
         {
-          "className": "jp-enh-cell-to-code",
+          "cellType": "markdown",
           "command": "notebook:change-cell-to-code",
           "icon": "@jlab-enhanced/cell-toolbar:code",
           "tooltip": "Convert to Code Cell"
         },
         {
-          "className": "jp-enh-cell-to-md",
+          "cellType": "code",
           "command": "notebook:change-cell-to-markdown",
           "icon": "ui-components:markdown",
           "tooltip": "Convert to Markdown Cell"
         },
         {
-          "className": "jp-enh-cell-format",
+          "cellType": "code",
           "command": "jupyterlab_code_formatter:format",
           "icon": "@jlab-enhanced/cell-toolbar:format",
           "tooltip": "Format Cell"
@@ -58,7 +58,7 @@
           "type": "array",
           "items": { "$ref": "#/definitions/menuItem" }
         }
-      ],
+      ]
     }
   },
   "additionalProperties": false,
@@ -70,7 +70,7 @@
         "command": { "type": "string" },
         "icon": { "type": "string" },
         "tooltip": { "type": "string" },
-        "className": { "type": "string" }
+        "cellType": { "type": "string" }
       },
       "additionalProperties": false,
       "required": ["command", "icon"]

--- a/src/cellmenu.ts
+++ b/src/cellmenu.ts
@@ -39,7 +39,7 @@ export class CellMenu extends Widget {
     changes?: IObservableList.IChangedArgs<ICellMenuItem>
   ): void {
     each(this.children(), widget => {
-      widget.parent = null;
+      widget.dispose();
     });
 
     const layout = this.layout as PanelLayout;
@@ -49,7 +49,7 @@ export class CellMenu extends Widget {
           new ToolbarButton({
             icon: LabIcon.resolve({ icon: entry.icon }),
             tooltip: entry.tooltip,
-            className: entry.className,
+            className: `jp-enh-cell-${entry.cellType || 'all'}`,
             onClick: (): void => {
               this._commands.execute(entry.command);
             }

--- a/src/cellmenu.ts
+++ b/src/cellmenu.ts
@@ -1,65 +1,64 @@
 import { ToolbarButton } from '@jupyterlab/apputils';
-import { markdownIcon } from '@jupyterlab/ui-components';
+import { IObservableList } from '@jupyterlab/observables';
+import { LabIcon } from '@jupyterlab/ui-components';
+import { each } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { PanelLayout, Widget } from '@lumino/widgets';
-import { codeIcon, deleteIcon, formatIcon } from './icon';
 import { ICellMenuItem } from './tokens';
 
 const CELL_MENU_CLASS = 'jp-enh-cell-menu';
-
-const FOREIGN_COMMANDS: ICellMenuItem[] = [
-  // Originate from @jupyterlab/notebook-extension
-  {
-    className: 'jp-enh-cell-to-code',
-    command: 'notebook:change-cell-to-code',
-    icon: codeIcon,
-    tooltip: 'Convert to Code Cell'
-  },
-  {
-    className: 'jp-enh-cell-to-md',
-    command: 'notebook:change-cell-to-markdown',
-    icon: markdownIcon,
-    tooltip: 'Convert to Markdown Cell'
-  },
-  // Originate from @ryantam626/jupyterlab_code_formatter
-  {
-    className: 'jp-enh-cell-format',
-    command: 'jupyterlab_code_formatter:format',
-    icon: formatIcon,
-    tooltip: 'Format Cell'
-  },
-  // Originate from @jupyterlab/notebook-extension
-  {
-    command: 'notebook:delete-cell',
-    icon: deleteIcon,
-    tooltip: 'Delete Selected Cells'
-  }
-];
 
 /**
  * Toolbar icon menu container
  */
 export class CellMenu extends Widget {
-  constructor(commands: CommandRegistry) {
+  constructor(
+    commands: CommandRegistry,
+    items: IObservableList<ICellMenuItem>
+  ) {
     super();
+    this._commands = commands;
+    this._items = items;
     this.layout = new PanelLayout();
     this.addClass(CELL_MENU_CLASS);
-    this._createMenu(commands);
+    this._itemsChanged(items);
+    this._items.changed.connect(this._itemsChanged, this);
   }
 
-  private _createMenu(commands: CommandRegistry): void {
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._items.changed.disconnect(this._itemsChanged, this);
+
+    super.dispose();
+  }
+
+  protected _itemsChanged(
+    items: IObservableList<ICellMenuItem>,
+    changes?: IObservableList.IChangedArgs<ICellMenuItem>
+  ): void {
+    each(this.children(), widget => {
+      widget.parent = null;
+    });
+
     const layout = this.layout as PanelLayout;
-    FOREIGN_COMMANDS.forEach(entry => {
-      if (commands.hasCommand(entry.command)) {
+    each(items.iter(), entry => {
+      if (this._commands.hasCommand(entry.command)) {
         layout.addWidget(
           new ToolbarButton({
-            ...entry,
+            icon: LabIcon.resolve({ icon: entry.icon }),
+            tooltip: entry.tooltip,
+            className: entry.className,
             onClick: (): void => {
-              commands.execute(entry.command);
+              this._commands.execute(entry.command);
             }
           })
         );
       }
     });
   }
+
+  private _commands: CommandRegistry;
+  private _items: IObservableList<ICellMenuItem>;
 }

--- a/src/celltoolbartracker.ts
+++ b/src/celltoolbartracker.ts
@@ -25,20 +25,20 @@ import { ICellMenuItem } from './tokens';
 const DEFAULT_LEFT_MENU: ICellMenuItem[] = [
   // Originate from @jupyterlab/notebook-extension
   {
-    className: 'jp-enh-cell-to-code',
+    cellType: 'markdown',
     command: 'notebook:change-cell-to-code',
     icon: codeIcon,
     tooltip: 'Convert to Code Cell'
   },
   {
-    className: 'jp-enh-cell-to-md',
+    cellType: 'code',
     command: 'notebook:change-cell-to-markdown',
     icon: markdownIcon,
     tooltip: 'Convert to Markdown Cell'
   },
   // Originate from @ryantam626/jupyterlab_code_formatter
   {
-    className: 'jp-enh-cell-format',
+    cellType: 'code',
     command: 'jupyterlab_code_formatter:format',
     icon: formatIcon,
     tooltip: 'Format Cell'
@@ -54,26 +54,23 @@ const DEFAULT_LEFT_MENU: ICellMenuItem[] = [
 const POSITIONED_BUTTONS: ICellMenuItem[] = [
   // Originate from @jupyterlab/notebook-extension
   {
-    className: 'jp-enh-cell-run',
+    cellType: 'code',
     command: 'notebook:run-cell',
     icon: runIcon,
     tooltip: 'Run Selected Cells'
   },
   // { className: 'jp-enh-cell-interrupt', command: 'notebook:interrupt-kernel', icon: stopIcon },
   {
-    className: 'jp-enh-cell-up',
     command: 'notebook:move-cell-up',
     icon: caretUpEmptyThinIcon,
     tooltip: 'Move Selected Cells Up'
   },
   {
-    className: 'jp-enh-cell-down',
     command: 'notebook:move-cell-down',
     icon: caretDownEmptyThinIcon,
     tooltip: 'Move Selected Cells Down'
   },
   {
-    className: 'jp-enh-cell-insert',
     command: 'notebook:insert-cell-below',
     icon: addIcon,
     tooltip: 'Insert Cell'
@@ -155,17 +152,17 @@ export class CellToolbarTracker implements IDisposable {
 
       POSITIONED_BUTTONS.forEach(entry => {
         if (this._commands.hasCommand(entry.command)) {
-          const { className, command, ...others } = entry;
+          const { cellType, command, ...others } = entry;
+          const shortName = command.split(':')[1];
           const button = new PositionedButton({
             ...others,
             callback: (): void => {
               this._commands.execute(command);
-            }
+            },
+            className: shortName && `jp-enh-cell-${shortName}`
           });
           button.addClass(CELL_BAR_CLASS);
-          if (className) {
-            button.addClass(className);
-          }
+          button.addClass(`jp-enh-cell-${cellType || 'all'}`);
           (cell.layout as PanelLayout).addWidget(button);
         }
       });

--- a/src/celltoolbarwidget.ts
+++ b/src/celltoolbarwidget.ts
@@ -4,6 +4,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import { CellMenu } from './cellmenu';
 import { TagTool } from './tagbar';
+import { ICellMenuItem } from './tokens';
 
 /**
  * Cell Toolbar Widget
@@ -12,21 +13,30 @@ export class CellToolbarWidget extends Widget {
   constructor(
     commands: CommandRegistry,
     model: ICellModel,
-    tagsList: ObservableList<string>
+    tagsList: ObservableList<string>,
+    leftMenuItems?: ObservableList<ICellMenuItem>,
+    rightMenuItems?: ObservableList<ICellMenuItem>
   ) {
     super();
     this.layout = new PanelLayout();
-    this._create(commands, model, tagsList);
+    this._create(commands, model, tagsList, leftMenuItems, rightMenuItems);
     this.addClass('jp-enh-cell-toolbar');
   }
 
   private _create(
     commands: CommandRegistry,
     model: ICellModel,
-    tagsList: ObservableList<string>
+    tagsList: ObservableList<string>,
+    leftMenuItems?: ObservableList<ICellMenuItem>,
+    rightMenuItems?: ObservableList<ICellMenuItem>
   ): void {
     const layout = this.layout as PanelLayout;
-    layout.addWidget(new CellMenu(commands));
+    if (leftMenuItems?.length > 0) {
+      layout.addWidget(new CellMenu(commands, leftMenuItems));
+    }
     layout.addWidget(new TagTool(model, tagsList));
+    if (rightMenuItems?.length > 0) {
+      layout.addWidget(new CellMenu(commands, rightMenuItems));
+    }
   }
 }

--- a/src/celltoolbarwidget.ts
+++ b/src/celltoolbarwidget.ts
@@ -14,29 +14,19 @@ export class CellToolbarWidget extends Widget {
     commands: CommandRegistry,
     model: ICellModel,
     tagsList: ObservableList<string>,
-    leftMenuItems?: ObservableList<ICellMenuItem>,
-    rightMenuItems?: ObservableList<ICellMenuItem>
+    leftMenuItems: ObservableList<ICellMenuItem>,
+    rightMenuItems: ObservableList<ICellMenuItem>
   ) {
     super();
     this.layout = new PanelLayout();
-    this._create(commands, model, tagsList, leftMenuItems, rightMenuItems);
     this.addClass('jp-enh-cell-toolbar');
-  }
 
-  private _create(
-    commands: CommandRegistry,
-    model: ICellModel,
-    tagsList: ObservableList<string>,
-    leftMenuItems?: ObservableList<ICellMenuItem>,
-    rightMenuItems?: ObservableList<ICellMenuItem>
-  ): void {
-    const layout = this.layout as PanelLayout;
-    if (leftMenuItems?.length > 0) {
-      layout.addWidget(new CellMenu(commands, leftMenuItems));
-    }
-    layout.addWidget(new TagTool(model, tagsList));
-    if (rightMenuItems?.length > 0) {
-      layout.addWidget(new CellMenu(commands, rightMenuItems));
-    }
+    (this.layout as PanelLayout).addWidget(
+      new CellMenu(commands, leftMenuItems)
+    );
+    (this.layout as PanelLayout).addWidget(new TagTool(model, tagsList));
+    (this.layout as PanelLayout).addWidget(
+      new CellMenu(commands, rightMenuItems)
+    );
   }
 }

--- a/src/positionedbutton.ts
+++ b/src/positionedbutton.ts
@@ -1,3 +1,4 @@
+import { LabIcon } from '@jupyterlab/ui-components';
 import { Message } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { ICellMenuItem } from './tokens';
@@ -84,7 +85,7 @@ namespace Private {
       button.classList.add(item.className);
     }
     button.appendChild(
-      item.icon.element({
+      LabIcon.resolve({ icon: item.icon }).element({
         elementPosition: 'center',
         elementSize: 'normal',
         tag: 'span'

--- a/src/positionedbutton.ts
+++ b/src/positionedbutton.ts
@@ -11,6 +11,10 @@ export interface IPositionedButton extends Omit<ICellMenuItem, 'command'> {
    * Button callback
    */
   callback: () => void;
+  /**
+   * Custom class name
+   */
+  className?: string;
 }
 
 /**

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -13,7 +13,7 @@ export interface ICellMenuItem {
   /**
    * Icon for the item
    */
-  icon: LabIcon;
+  icon: LabIcon | string;
   /**
    * Icon tooltip
    */

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -19,7 +19,9 @@ export interface ICellMenuItem {
    */
   tooltip?: string;
   /**
-   * Item class name
+   * Type of cell it applies on
+   *
+   * Undefined if it applies on all cell types
    */
-  className?: string;
+  cellType?: 'code' | 'markdown' | 'raw';
 }

--- a/style/base.css
+++ b/style/base.css
@@ -1,3 +1,8 @@
+/* Patch default to reduce vertical blank space */
+.jp-Notebook .jp-Cell {
+  padding: 0px var(--jp-cell-padding);
+}
+
 .lm-Widget.jp-enh-cell-button {
   background: none;
   border: none;
@@ -48,7 +53,8 @@
   margin-left: calc(
     var(--jp-cell-collapser-width) + var(--jp-cell-prompt-width)
   );
-  padding-bottom: 2px;
+  padding: 2px 0px;
+  min-height: 22px;
 }
 
 .jp-enh-cell-menu {
@@ -84,7 +90,8 @@
   flex-direction: row;
 }
 
-.jp-enh-cell-tags .tag {
+.jp-enh-cell-tags .tag,
+.jp-enh-cell-tags .tag input.add-tag {
   font-size: 0.8em;
   height: 18px;
   margin: 0px 2px;

--- a/style/base.css
+++ b/style/base.css
@@ -90,9 +90,8 @@
   flex-direction: row;
 }
 
-.jp-enh-cell-tags .tag,
-.jp-enh-cell-tags .tag input.add-tag {
-  font-size: 0.8em;
+.jp-enh-cell-tags .tag {
+  font-size: 0.9em;
   height: 18px;
   margin: 0px 2px;
   padding: 0px 2px;
@@ -100,6 +99,10 @@
   cursor: pointer;
   /* Needed to ensure correct display */
   max-width: unset;
+}
+
+.jp-enh-cell-tags .tag input.add-tag {
+  font-size: 1em;
 }
 
 .jp-mod-active .jp-enh-cell-tags .tag.unapplied-tag {

--- a/style/base.css
+++ b/style/base.css
@@ -27,23 +27,23 @@
   display: block;
 }
 
-.jp-enh-cell-run {
+.jp-enh-cell-run-cell {
   left: 44px;
   top: 46px;
 }
 
-.jp-enh-cell-up {
+.jp-enh-cell-move-cell-up {
   top: 20px;
   left: -10px;
 }
 
-.jp-enh-cell-down {
+.jp-enh-cell-move-cell-down {
   top: 36px;
   left: -10px;
 }
 
-.jp-enh-cell-insert {
-  bottom: -10px;
+.jp-enh-cell-insert-cell-below {
+  bottom: -11px;
   left: -10px;
 }
 
@@ -71,27 +71,27 @@
   cursor: pointer;
 }
 
-.jp-ToolbarButton .jp-enh-cell-to-md,
-.jp-ToolbarButton .jp-enh-cell-to-code,
-.jp-ToolbarButton .jp-enh-cell-format,
-.jp-MarkdownCell.jp-mod-active .jp-enh-cell-run,
-.jp-RawCell.jp-mod-active .jp-enh-cell-run {
+.jp-enh-cell-menu .jp-ToolbarButton button,
+.jp-MarkdownCell.jp-mod-active .jp-enh-cell-run-cell,
+.jp-RawCell.jp-mod-active .jp-enh-cell-run-cell {
   display: none;
 }
 
-.jp-CodeCell .jp-ToolbarButton .jp-enh-cell-to-md,
-.jp-MarkdownCell .jp-ToolbarButton .jp-enh-cell-to-code,
-.jp-CodeCell .jp-ToolbarButton .jp-enh-cell-format {
+.jp-enh-cell-menu .jp-ToolbarButton .jp-enh-cell-all,
+.jp-CodeCell .jp-ToolbarButton .jp-enh-cell-code,
+.jp-MarkdownCell .jp-ToolbarButton .jp-enh-cell-markdown,
+.jp-RawCell .jp-ToolbarButton .jp-enh-cell-raw {
   display: block;
 }
 
 .jp-enh-cell-tags {
   display: flex;
   flex-direction: row;
+  flex: 1 1 auto;
 }
 
 .jp-enh-cell-tags .tag {
-  font-size: 0.9em;
+  font-size: 0.85em;
   height: 18px;
   margin: 0px 2px;
   padding: 0px 2px;


### PR DESCRIPTION
Fixes #11 

This add the possibility to define custom icon actions in two places - a left menu and a right menu. In the example below, the run action is added on the right menu:

![image](https://user-images.githubusercontent.com/8435071/107125567-0bb46480-68ab-11eb-96d0-916c5c457552.png)

Note: this sets a vertical space between the cells in which the toolbar will display. This avoid element editor motion when the cell is selected that may end up with the user clicking on a toolbar element.