### PR TITLE
Enable strict null checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@jupyterlab/settingregistry": "^3.0.0",
     "@jupyterlab/ui-components": "^3.0.0",
     "@lumino/commands": "^1.12.0",
+    "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/widgets": "^1.16.1"
   },

--- a/src/celltoolbartracker.ts
+++ b/src/celltoolbartracker.ts
@@ -109,8 +109,10 @@ export class CellToolbarTracker implements IDisposable {
       this._settings.changed.disconnect(this._onSettingsChanged, this);
     }
 
-    const cells = this._panel.context.model.cells;
-    cells.changed.disconnect(this.updateConnectedCells, this);
+    const cells = this._panel?.context.model.cells;
+    if (cells) {
+      cells.changed.disconnect(this.updateConnectedCells, this);
+    }
     this._panel = null;
   }
 
@@ -162,8 +164,8 @@ export class CellToolbarTracker implements IDisposable {
     }
   }
 
-  private _getCell(model: ICellModel): Cell {
-    return this._panel.content.widgets.find(widget => widget.model === model);
+  private _getCell(model: ICellModel): Cell | undefined {
+    return this._panel?.content.widgets.find(widget => widget.model === model);
   }
 
   private _findToolbarWidgets(cell: Cell): Widget[] {
@@ -185,7 +187,7 @@ export class CellToolbarTracker implements IDisposable {
    */
   private _onSettingsChanged(): void {
     // Update menu items
-    const leftItems = (this._settings.composite['leftMenu'] as any) as
+    const leftItems = (this._settings?.composite['leftMenu'] as any) as
       | ICellMenuItem[]
       | null;
     // Test to avoid useless signal emission
@@ -199,7 +201,7 @@ export class CellToolbarTracker implements IDisposable {
     } else {
       this._leftMenuItems.pushAll(DEFAULT_LEFT_MENU);
     }
-    const rightItems = ((this._settings.composite['rightMenu'] as any) ||
+    const rightItems = ((this._settings?.composite['rightMenu'] as any) ||
       []) as ICellMenuItem[];
     // Test to avoid useless signal emission
     if (this._rightMenuItems.length > 0) {
@@ -211,7 +213,7 @@ export class CellToolbarTracker implements IDisposable {
 
     // Update tags
     const newDefaultTags =
-      (this._settings.composite['defaultTags'] as string[]) || [];
+      (this._settings?.composite['defaultTags'] as string[]) || [];
     // Update default tag in shared tag list
     const toAdd = newDefaultTags.filter(
       tag => !this._previousDefaultTags.includes(tag)
@@ -226,11 +228,13 @@ export class CellToolbarTracker implements IDisposable {
 
     // Update left space
     const leftSpace = (this._settings?.composite['leftSpace'] as number) || 0;
-    this._panel.node
-      .querySelectorAll(`div.${LEFT_SPACER_CLASSNAME}`)
-      .forEach(node => {
-        (node as HTMLElement).style.width = `${leftSpace}px`;
-      });
+    if (this._panel) {
+      this._panel.node
+        .querySelectorAll(`div.${LEFT_SPACER_CLASSNAME}`)
+        .forEach(node => {
+          (node as HTMLElement).style.width = `${leftSpace}px`;
+        });
+    }
   }
 
   private _allTags: ObservableList<string> = new ObservableList<string>();
@@ -240,7 +244,7 @@ export class CellToolbarTracker implements IDisposable {
     ICellMenuItem
   >();
   private _previousDefaultTags = new Array<string>();
-  private _panel: NotebookPanel;
+  private _panel: NotebookPanel | null;
   private _rightMenuItems: ObservableList<ICellMenuItem> = new ObservableList<
     ICellMenuItem
   >();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ const extension: JupyterFrontEndPlugin<void> = {
     app: JupyterFrontEnd,
     settingRegistry: ISettingRegistry | null
   ) => {
-    const settings = await settingRegistry.load(`${EXTENSION_ID}:plugin`);
+    const settings =
+      (await settingRegistry?.load(`${EXTENSION_ID}:plugin`)) ?? null;
     app.docRegistry.addWidgetExtension(
       'Notebook',
       new CellBarExtension(app.commands, settings)

--- a/src/tagbar.ts
+++ b/src/tagbar.ts
@@ -133,15 +133,14 @@ export class TagTool extends Widget {
     });
 
     // Sort the widgets in tag alphabetical order
-    // TODO: find an alternative way to order the tags?
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    //  - undefined matches the AddTag widget
-    const orderedTags = allTags.concat([undefined]);
     [...layout.widgets].forEach((widget: Widget, index: number) => {
-      const tagIndex = orderedTags.findIndex(
+      let tagIndex = allTags.findIndex(
         tag => (widget as TagWidget).name === tag
       );
+      // Handle AddTag widget case
+      if (tagIndex === -1) {
+        tagIndex = allTags.length;
+      }
       if (tagIndex !== index) {
         layout.insertWidget(tagIndex, widget);
       }

--- a/src/tagbar.ts
+++ b/src/tagbar.ts
@@ -133,12 +133,16 @@ export class TagTool extends Widget {
     });
 
     // Sort the widgets in tag alphabetical order
+    // TODO: find an alternative way to order the tags?
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
     //  - undefined matches the AddTag widget
+    const orderedTags = allTags.concat([undefined]);
     [...layout.widgets].forEach((widget: Widget, index: number) => {
-      const tagIndex = allTags.findIndex(
+      const tagIndex = orderedTags.findIndex(
         tag => (widget as TagWidget).name === tag
       );
-      if (tagIndex !== index && tagIndex !== allTags.length - 1) {
+      if (tagIndex !== index) {
         layout.insertWidget(tagIndex, widget);
       }
     });

--- a/src/tagbar.ts
+++ b/src/tagbar.ts
@@ -134,12 +134,11 @@ export class TagTool extends Widget {
 
     // Sort the widgets in tag alphabetical order
     //  - undefined matches the AddTag widget
-    const orderedTags = allTags.concat([undefined]);
     [...layout.widgets].forEach((widget: Widget, index: number) => {
-      const tagIndex = orderedTags.findIndex(
+      const tagIndex = allTags.findIndex(
         tag => (widget as TagWidget).name === tag
       );
-      if (tagIndex !== index) {
+      if (tagIndex !== index && tagIndex !== allTags.length - 1) {
         layout.insertWidget(tagIndex, widget);
       }
     });
@@ -186,7 +185,7 @@ export class TagTool extends Widget {
    */
   protected onCellMetadataChanged(
     metadata: IObservableJSON,
-    changes: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue>
+    changes: IObservableMap.IChangedArgs<ReadonlyPartialJSONValue | undefined>
   ): void {
     if (changes.key === 'tags') {
       const oldTags = [...new Set((changes.oldValue as string[]) || [])];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "target": "es2017",
     "types": []
   },


### PR DESCRIPTION
The main motivation was to make sure to not access the setting registry if the service is not available (optional), but this also applies to the rest of the code base.