### PR TITLE
Set packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "watch:labextension": "jupyter labextension watch .",
     "watch:src": "tsc -w"
   },
+  "packageManager": "yarn@3.5.0",
   "dependencies": {
     "@jupyterlab/application": "^3.4.0-rc.0",
     "@jupyterlab/attachments": "^3.4.0-rc.0",


### PR DESCRIPTION
Prevent dependabot of using a wrong yarn version that may result in yarn.lock format changes